### PR TITLE
[#1] Fix Travis build issue, test with JDK 8 + 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: java
 
-jdk:
-  - oraclejdk8
+dist: xenial
+
+jdk: 
+  - openjdk8
+  - openjdk11
+
+script:
+  - mvn -B test javadoc:javadoc
 
 after_success:
-  - mvn clean verify jacoco:report coveralls:report
+  - ./ci_coverage.sh

--- a/ci_coverage.sh
+++ b/ci_coverage.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ $(bc -l <<< "$(java -version 2>&1 | awk -F '\"' '/version/ {print $2}' | awk -F'.' '{print $1"."$2}') >= 11") -eq 1 ]]; then
+    mvn -B verify jacoco:report coveralls:report
+else
+    echo "Not Java 11"
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.xlate</groupId>
   <artifactId>validators</artifactId>
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>jakarta.el</groupId>
       <artifactId>jakarta.el-api</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <optional>true</optional>
     </dependency>
 
@@ -100,9 +100,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>6.1.0.Final</version>
+      <version>6.1.1.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -149,36 +149,6 @@
       </plugins>
     </pluginManagement>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <phase>compile</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <inherited>false</inherited>
-            <configuration>
-              <release>8</release>
-            </configuration>
-          </execution>
-          <!-- <execution>
-            <id>jdk9</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <release>9</release>
-              <compileSourceRoots>
-                <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
-              </compileSourceRoots>
-              <multiReleaseOutput>true</multiReleaseOutput>
-            </configuration>
-          </execution> -->
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -335,10 +305,35 @@
       </build>
     </profile>
     <profile>
-      <id>java9</id>
+      <id>multirelease</id>
       <activation>
         <jdk>[9,)</jdk>
       </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>default-compile</id>
+                  <phase>compile</phase>
+                  <goals>
+                    <goal>compile</goal>
+                  </goals>
+                  <inherited>false</inherited>
+                  <configuration>
+                    <release>8</release>
+                  </configuration>
+                </execution>
+                <!-- <execution> <id>module-compile</id> <goals> <goal>compile</goal> </goals> <configuration> <release>9</release> <compileSourceRoots> <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+                  </compileSourceRoots> <multiReleaseOutput>true</multiReleaseOutput> </configuration> </execution> -->
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
       <properties>
         <!-- For surefire tests -->
         <argLine>--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</argLine>

--- a/src/main/java/io/xlate/validation/internal/constraintvalidators/JdbcStatementValidator.java
+++ b/src/main/java/io/xlate/validation/internal/constraintvalidators/JdbcStatementValidator.java
@@ -71,20 +71,20 @@ public class JdbcStatementValidator implements BooleanExpression, ConstraintVali
         return valid;
     }
 
-    DataSource getDataSource(String dataSourceLookup) {
-        final DataSource dataSource;
+    static DataSource getDataSource(String dataSourceLookup) {
+        final DataSource source;
 
         try {
             if (dataSourceLookup.isEmpty()) {
-                dataSource = InitialContext.doLookup("java:comp/DefaultDataSource");
+                source = InitialContext.doLookup("java:comp/DefaultDataSource");
             } else {
-                dataSource = InitialContext.doLookup(dataSourceLookup);
+                source = InitialContext.doLookup(dataSourceLookup);
             }
         } catch (NamingException e) {
             throw new ValidationException("DataSource not found", e);
         }
 
-        return dataSource;
+        return source;
     }
 
     boolean executeQuery(ELProcessor processor, String sql, String[] parameters) {

--- a/src/test/java/io/xlate/validation/internal/constraintvalidators/JdbcStatementValidatorTest.java
+++ b/src/test/java/io/xlate/validation/internal/constraintvalidators/JdbcStatementValidatorTest.java
@@ -89,7 +89,7 @@ class JdbcStatementValidatorTest {
         context.createSubcontext("java:comp");
         context.bind("java:comp/DefaultDataSource", dataSource);
         try {
-            assertEquals(dataSource, target.getDataSource(""));
+            assertEquals(dataSource, JdbcStatementValidator.getDataSource(""));
         } finally {
             context.close();
         }
@@ -109,7 +109,7 @@ class JdbcStatementValidatorTest {
         String lookup = "java:comp/env/jdbc/testDataSource";
         context.bind(lookup, dataSource);
         try {
-            assertEquals(dataSource, target.getDataSource(lookup));
+            assertEquals(dataSource, JdbcStatementValidator.getDataSource(lookup));
         } finally {
             context.close();
         }
@@ -130,7 +130,7 @@ class JdbcStatementValidatorTest {
         ValidationException ex;
         try {
             ex = assertThrows(ValidationException.class, () -> {
-                target.getDataSource(lookup);
+                JdbcStatementValidator.getDataSource(lookup);
             });
         } finally {
             context.close();


### PR DESCRIPTION
- Update Hibernate dependency
- Prepare for multirelease build (module-info not possible without EL
library changes)
- Use cloned `DateFormat` objects in `DateTimeValidator` rather than
constructed instances each time.
- Rename shadowing variable in `JdbcStatementValidator`, make method
`static`